### PR TITLE
Trezor Connect does not need transactions

### DIFF
--- a/lib/pochette/base_trezor_transaction_builder.rb
+++ b/lib/pochette/base_trezor_transaction_builder.rb
@@ -12,6 +12,7 @@ class Pochette::BaseTrezorTransactionBuilder < Pochette::BaseTransactionBuilder
     :change_address => C::Maybe[String],
     :fee_per_kb => C::Maybe[C::Num],
     :spend_all => C::Maybe[C::Bool],
+    :trezor_connect => C::Maybe[C::Bool]
   }) => C::Any
   def initialize(options)
     options = options.dup
@@ -20,7 +21,7 @@ class Pochette::BaseTrezorTransactionBuilder < Pochette::BaseTransactionBuilder
     return unless valid?
     build_trezor_inputs
     build_trezor_outputs
-    build_transactions
+    build_transactions unless options[:trezor_connect]
   end
 
   Contract C::None => C::Maybe[({
@@ -30,7 +31,7 @@ class Pochette::BaseTrezorTransactionBuilder < Pochette::BaseTransactionBuilder
     :outputs => C::ArrayOf[[String, C::Num]],
     :inputs => C::ArrayOf[[String, String, Integer, C::Num, String]],
     :utxos_to_blacklist => C::ArrayOf[[String, Integer]],
-    :transactions => C::ArrayOf[Hash],
+    :transactions => C::Maybe[C::ArrayOf[Hash]],
     :trezor_inputs => C::ArrayOf[{
       address_n: C::ArrayOf[Integer],
       prev_hash: String,

--- a/lib/pochette/version.rb
+++ b/lib/pochette/version.rb
@@ -1,3 +1,3 @@
 module Pochette
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end

--- a/spec/backends/bitcoin_cash_wrapper_spec.rb
+++ b/spec/backends/bitcoin_cash_wrapper_spec.rb
@@ -52,27 +52,27 @@ describe Pochette::Backends::BitcoinCashWrapper do
     stub_rpc('getrawtransaction', {},
       *(12.times.collect{|i| "incoming_for_getrawtransaction_#{i}" }))
     backend.incoming_for(addresses, 30.days.ago).tap do |r|
-      r.size.should == 6
-      r.should == [
-        [ 500000, "bchtest:qqkcrvssm6m7yfr4e4ljlkst7kpdmhya5udm4gne8z",
+      r.size.should eq(6)
+      r.should eq([
+        [500000, "bchtest:qqkcrvssm6m7yfr4e4ljlkst7kpdmhya5udm4gne8z",
           "fb401691795a73e0160252c00af18327a15006fcdf877ccca0c116809669032e", 1629, 0,
-          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh"],
+          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh", nil],
         [100000, "bchtest:qzade0awfkp62twzermgvptx8twf6jfz5c7nxkhzm3",
           "250978b77fe1310d6c72239d9e9589d7ac3dc6edf1b2412806ace5104553da34", 1648, 1,
-          "bchtest:qzsxudft5t2rh22ltld29krn762musysdc4qjsytud"],
+          "bchtest:qzsxudft5t2rh22ltld29krn762musysdc4qjsytud", nil],
         [500000, "bchtest:qz5zujysvmxgzuk3474gfwt049sne5y42cfumfes4c",
           "d9afd460b0a5e065fdd87bf97cb1843a29ea588c59daabd1609794e8166bb75f", 1648, 0,
-          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh"],
-        [ 100000, "bchtest:qzade0awfkp62twzermgvptx8twf6jfz5c7nxkhzm3",
+          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh", nil],
+        [100000, "bchtest:qzade0awfkp62twzermgvptx8twf6jfz5c7nxkhzm3",
           "5bd72a4aa7818f47ac8943e3e17519be00c46530760860e608d898d728b9d46e", 553, 1,
-          "bchtest:qzjpek6909ewr9lg92m87s5c84wh7y0ysq49x34nq3"],
-        [ 500000, "bchtest:qzhlqqgn4cekgcd2zcf74j2uxfum2ve8jvq7lsfnlf",
+          "bchtest:qzjpek6909ewr9lg92m87s5c84wh7y0ysq49x34nq3", nil],
+        [500000, "bchtest:qzhlqqgn4cekgcd2zcf74j2uxfum2ve8jvq7lsfnlf",
           "b252037526ecb616ab5901552abb903f00bf73400a1fc49b5b5bd699b84bce77", 1632, 0,
-          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh"],
-        [ 500000, "bchtest:qrg50axjjgg9d2nd334907926ntg2gu4ncfd5ud36f",
+          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh", nil],
+        [500000, "bchtest:qrg50axjjgg9d2nd334907926ntg2gu4ncfd5ud36f",
           "ff768084764a05d1de72628432c0a4419538b2786089ec8ad009f6096bc69fe1", 1660, 0,
-          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh"],
-      ]
+          "bchtest:qrqp5l9pddrmu5xtm0rqwf8hq82j6ag4vcatt8vqyh", nil],
+      ])
     end
   end
   

--- a/spec/bch_trezor_transaction_builder_spec.rb
+++ b/spec/bch_trezor_transaction_builder_spec.rb
@@ -203,4 +203,115 @@ describe Pochette::BchTransactionBuilder do
     expect(Pochette::BchTrezorTransactionBuilder.backend.backend).not_to have_received :list_unspent
     expect(Pochette::BchTrezorTransactionBuilder.backend.backend).not_to have_received :list_transactions
   end
+
+  it 'receives bip32 addresses and formats output for trezor connect' do
+    xpub1 = 'xpub661MyMwAqRbcGCmcnz4JtnieVyuvgQFGqZqw3KS1g9khndpF3segkAYbYCKKaQ9Di2ZuWLaZU4Axt7TrKq41aVYx8XTbDbQFzhhDMntKLU5'
+    xpub2 = 'xpub661MyMwAqRbcFwc3Nmz8WmMU9okGmeVSmuprwNHCVsfhy6vMyg6g79octqwNftK4g62TMWmb7UtVpnAWnANzqwtKrCDFe2UaDCv1HoErssE'
+    xpub3 = 'xpub661MyMwAqRbcGkqPSKVkwTMtFZzEpbWXjM4t1Dv1XQbfMxtyLRGupWkp3fcSCDtp6nd1AUrRtq8tnFGTYgkY1pB9muwzaBDnJSMo2rVENhz'
+    addresses = [
+      ["bchtest:pza05cp9mshq7xx5h8e95cwsgv9lv0dhgyux7cru05", [42, 1, 1]],
+      [[xpub1, xpub2, xpub3], [42, 1, 1], 2]
+    ]
+    outputs = [["bchtest:qpaps04mxmjkv4xmhua7hmmww4999wlcl5sewjt0m0", 6_0000_0000]]
+    transaction = Pochette::BchTrezorTransactionBuilder
+      .new(bip32_addresses: addresses,
+           outputs: outputs,
+           trezor_connect: true)
+    transaction.should be_valid
+
+    transaction.as_hash.should == {
+      input_total: 7_0000_0000,
+      output_total: 6_9999_0000,
+      fee: 10000,
+      outputs: [
+        ["bchtest:qpaps04mxmjkv4xmhua7hmmww4999wlcl5sewjt0m0", 600000000],
+        ["bchtest:pza05cp9mshq7xx5h8e95cwsgv9lv0dhgyux7cru05", 99990000]
+      ],
+      trezor_outputs: [
+        { script_type: 'PAYTOADDRESS',
+          address: "mreXn2qhKo7tnLnA2xCnBUSc1rC3W76FHG",
+          amount: 6_0000_0000 },
+        { script_type: 'PAYTOSCRIPTHASH',
+          address: "2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9",
+          amount: 9999_0000 },
+      ],
+      inputs: [
+        [ "bchtest:pza05cp9mshq7xx5h8e95cwsgv9lv0dhgyux7cru05",
+          "956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        [ "bchtest:pza05cp9mshq7xx5h8e95cwsgv9lv0dhgyux7cru05",
+          "0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        [ "bchtest:pza05cp9mshq7xx5h8e95cwsgv9lv0dhgyux7cru05",
+          "1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        [ "bchtest:pqgn6cjf37zdk79asdh3ng44tesn648xscf0nw69xk",
+          "eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee", 0, 100000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"]
+      ],
+      trezor_inputs: [
+        { address_n: [42,1,1],
+          prev_hash: "956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40",
+          prev_index: 1,
+          amount: 200000000
+        },
+        { address_n: [42,1,1],
+          prev_hash: "0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72",
+          prev_index: 1,
+          amount: 200000000
+        },
+        { address_n: [42, 1, 1],
+          prev_hash: "1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055",
+          prev_index: 1,
+          amount: 200000000
+        },
+        { address_n: [42,1,1],
+          prev_hash: "eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee",
+          prev_index: 0,
+          script_type: 'SPENDMULTISIG',
+          amount: 100000000,
+          multisig: {
+            signatures: ['','',''],
+            m: 2,
+            pubkeys: [
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: 'a6d47170817f78094180f1a7a3a9df7634df75fa9604d71b87e92a5a6bf9d30a',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '03142b0a6fa6943e7276ddc42582c6b169243d289ff17e7c8101797047eed90c9b',
+                }
+              },
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: '8c9151740446b9e0063ca934df66c5e14121a0b4d8a360748f1b19bfef675460',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '027565ceb190647ec5c566805ebc5cb6166ae2ee1d4995495f61b9eff371ec0e61',
+                }
+              },
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: 'de5bc5918414df3777ff52ae733bdbc87431485cfd39aea65da6133e183ef68a',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '028776ff18f0f3808d6d42749a6e2baee5c75c3f7ae07445403a3a5690d580a0af',
+                }
+              }
+            ]
+          }
+        }
+      ],
+      transactions: nil,
+      utxos_to_blacklist: [
+        ["956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40", 1],
+        ["0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72", 1],
+        ["1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055", 1],
+        ["eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee", 0],
+      ],
+    }
+  end
 end

--- a/spec/trezor_transaction_builder_spec.rb
+++ b/spec/trezor_transaction_builder_spec.rb
@@ -193,4 +193,108 @@ describe Pochette::BtcTransactionBuilder do
     expect(Pochette::BtcTrezorTransactionBuilder.backend).not_to have_received :list_unspent
     expect(Pochette::BtcTrezorTransactionBuilder.backend).not_to have_received :list_transactions
   end
+
+  it 'receives bip32 addresses and formats output for trezor connect' do
+    xpub1 = 'xpub661MyMwAqRbcGCmcnz4JtnieVyuvgQFGqZqw3KS1g9khndpF3segkAYbYCKKaQ9Di2ZuWLaZU4Axt7TrKq41aVYx8XTbDbQFzhhDMntKLU5'
+    xpub2 = 'xpub661MyMwAqRbcFwc3Nmz8WmMU9okGmeVSmuprwNHCVsfhy6vMyg6g79octqwNftK4g62TMWmb7UtVpnAWnANzqwtKrCDFe2UaDCv1HoErssE'
+    xpub3 = 'xpub661MyMwAqRbcGkqPSKVkwTMtFZzEpbWXjM4t1Dv1XQbfMxtyLRGupWkp3fcSCDtp6nd1AUrRtq8tnFGTYgkY1pB9muwzaBDnJSMo2rVENhz'
+    addresses = [
+      ["2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9", [42, 1, 1]],
+      [[xpub1, xpub2, xpub3], [42, 1, 1], 2]
+    ]
+    outputs = [["mreXn2qhKo7tnLnA2xCnBUSc1rC3W76FHG", 6_0000_0000]]
+    transaction = Pochette::BtcTrezorTransactionBuilder
+      .new(bip32_addresses: addresses,
+           outputs: outputs,
+           trezor_connect: true)
+    transaction.should be_valid
+
+    transaction.as_hash.should == {
+      input_total: 7_0000_0000,
+      output_total: 6_9999_0000,
+      fee: 10000,
+      outputs: [
+        ["mreXn2qhKo7tnLnA2xCnBUSc1rC3W76FHG", 600000000], 
+        ["2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9", 99990000]
+      ],
+      trezor_outputs: [
+        { script_type: 'PAYTOADDRESS',
+          address: "mreXn2qhKo7tnLnA2xCnBUSc1rC3W76FHG",
+          amount: 6_0000_0000 },
+        { script_type: 'PAYTOSCRIPTHASH',
+          address: "2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9",
+          amount: 9999_0000 },
+      ],
+      inputs: [
+        ["2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9",
+          "956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        ["2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9",
+          "0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        ["2NAHscN6XVqUPzBSJHC3fhkeF5SQVxiR9p9",
+          "1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055", 1, 200000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"],
+        ["2MtpP1aLi2bjFBPhPN7suFZwjgb2k2tBmCp",
+          "eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee", 0, 100000000,
+          "76a91420993489de25302418540f4b410c0c1d3e1d05a988ac"]
+      ],
+      trezor_inputs: [
+        { address_n: [42,1,1],
+          prev_hash: "956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40",
+          prev_index: 1},
+        { address_n: [42,1,1],
+          prev_hash: "0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72",
+          prev_index: 1},
+        { address_n: [42, 1, 1],
+          prev_hash: "1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055",
+          prev_index: 1},
+        { address_n: [42,1,1],
+          prev_hash: "eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee",
+          prev_index: 0,
+          script_type: 'SPENDMULTISIG',
+          multisig: {
+            signatures: ['','',''],
+            m: 2,
+            pubkeys: [
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: 'a6d47170817f78094180f1a7a3a9df7634df75fa9604d71b87e92a5a6bf9d30a',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '03142b0a6fa6943e7276ddc42582c6b169243d289ff17e7c8101797047eed90c9b',
+                }
+              },
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: '8c9151740446b9e0063ca934df66c5e14121a0b4d8a360748f1b19bfef675460',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '027565ceb190647ec5c566805ebc5cb6166ae2ee1d4995495f61b9eff371ec0e61',
+                }
+              },
+              { address_n: [42,1,1],
+                node: {
+                  chain_code: 'de5bc5918414df3777ff52ae733bdbc87431485cfd39aea65da6133e183ef68a',
+                  depth: 0, 
+                  child_num: 0, 
+                  fingerprint: 0,
+                  public_key: '028776ff18f0f3808d6d42749a6e2baee5c75c3f7ae07445403a3a5690d580a0af',
+                }
+              }
+            ]
+          }
+        }
+      ],
+      transactions: nil,
+      utxos_to_blacklist: [
+        ["956b30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968e40", 1],
+        ["0ded7f014fa3213e9b000bc81b8151bc6f2f926b9afea6e3643c8ad658353c72", 1],
+        ["1db1f22beb84e5fbe92c8c5e6e7f43d80aa5cfe5d48d83513edd9641fc00d055", 1],
+        ["eeeb30c3c4335f019dbee60c60d76994319473acac356f774c7858cd5c968eee", 0],
+      ],
+    }
+  end
 end


### PR DESCRIPTION
Trezor Connect does not need transactions, so the rpc call towards getrawtransaction is not needed.